### PR TITLE
(fix): Rename ngOutletContext (deprecated) to ngTemplateOutletContext

### DIFF
--- a/src/lib/treeview-item.component.html
+++ b/src/lib/treeview-item.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="item" class="treeview-item">
-    <ng-template [ngTemplateOutlet]="template" [ngOutletContext]="{item: item, onCollapseExpand: onCollapseExpand, onCheckedChange: onCheckedChange}">
+    <ng-template [ngTemplateOutlet]="template" [ngTemplateOutletContext]="{item: item, onCollapseExpand: onCollapseExpand, onCheckedChange: onCheckedChange}">
     </ng-template>
     <div *ngIf="!item.collapsed">
         <ngx-treeview-item [config]="config" *ngFor="let child of item.children" [item]="child" [template]="template" (checkedChange)="onChildCheckedChange(child, $event)">

--- a/src/lib/treeview.component.html
+++ b/src/lib/treeview.component.html
@@ -35,7 +35,7 @@
     </div>
 </ng-template>
 <div class="treeview-header">
-    <ng-template [ngTemplateOutlet]="headerTemplate || defaultHeaderTemplate" [ngOutletContext]="headerTemplateContext">
+    <ng-template [ngTemplateOutlet]="headerTemplate || defaultHeaderTemplate" [ngTemplateOutletContext]="headerTemplateContext">
     </ng-template>
 </div>
 <div [ngSwitch]="hasFilterItems">


### PR DESCRIPTION
 `ngOutletContext ` is deprecated since angular v4 and removed in angular v5.