### PR TITLE
Fixed access modifiers issue. Fixes #156

### DIFF
--- a/src/lib/dropdown-menu.directive.ts
+++ b/src/lib/dropdown-menu.directive.ts
@@ -11,6 +11,6 @@ import { DropdownDirective } from './dropdown.directive';
 })
 export class DropdownMenuDirective {
     constructor(
-        private dropdown: DropdownDirective
+        public dropdown: DropdownDirective
     ) { }
 }

--- a/src/lib/dropdown-toggle.directive.ts
+++ b/src/lib/dropdown-toggle.directive.ts
@@ -13,7 +13,7 @@ import { DropdownDirective } from './dropdown.directive';
 })
 export class DropdownToggleDirective {
     constructor(
-        private dropdown: DropdownDirective,
+        public dropdown: DropdownDirective,
         elementRef: ElementRef
     ) {
         dropdown.toggleElement = elementRef.nativeElement;


### PR DESCRIPTION
ngx-treeview: 6.0.0

```
ERROR in node_modules/ngx-treeview/src/dropdown-treeview.component.d.ts.DropdownTreeviewComponent.html(3,9): : Directive DropdownToggleDirective, Property 'dropdown' is private and only accessible within class 'DropdownToggleDirective'.
node_modules/ngx-treeview/src/dropdown-treeview.component.d.ts.DropdownTreeviewComponent.html(6,9): : Directive DropdownMenuDirective, Property 'dropdown' is private and only accessible within class 'DropdownMenuDirective'.
node_modules/ngx-treeview/src/dropdown-treeview.component.d.ts.DropdownTreeviewComponent.html(3,9): : Directive DropdownToggleDirective, Property 'dropdown' is private and only accessible within class 'DropdownToggleDirective'.
```