### PR TITLE
Add non-flat-selection mode

### DIFF
--- a/src/demo/book/book.component.html
+++ b/src/demo/book/book.component.html
@@ -35,6 +35,10 @@
             <input type="checkbox" class="form-check-input" [(ngModel)]="config.decoupleChildFromParent" id="decoupleChildFromParent">
             <label class="form-check-label" for="decoupleChildFromParent">decoupleChildFromParent</label>
           </div>
+          <div class="form-check">
+            <input type="checkbox" class="form-check-input" [(ngModel)]="config.flatSelection" id="flatSelection">
+            <label class="form-check-label" for="flatSelection">flatSelection</label>
+          </div>
           <div class="form-inline">
             <div class="form-group">
               <label for="maxHeight">maxHeight</label>

--- a/src/lib/treeview-config.ts
+++ b/src/lib/treeview-config.ts
@@ -7,6 +7,7 @@ export class TreeviewConfig {
     hasCollapseExpand = false;
     decoupleChildFromParent = false;
     maxHeight = 500;
+    flatSelection = true;
 
     get hasDivider(): boolean {
         return this.hasFilter || this.hasAllCheckBox || this.hasCollapseExpand;
@@ -18,6 +19,7 @@ export class TreeviewConfig {
         hasCollapseExpand?: boolean,
         decoupleChildFromParent?: boolean
         maxHeight?: number,
+        flatSelection?: boolean
     }): TreeviewConfig {
         const config = new TreeviewConfig();
         Object.assign(config, fields);

--- a/src/lib/treeview-helper.ts
+++ b/src/lib/treeview-helper.ts
@@ -6,7 +6,8 @@ export const TreeviewHelper = {
     findItemInList: findItemInList,
     findParent: findParent,
     removeItem: removeItem,
-    concatSelection: concatSelection
+    concatSelection: concatSelection,
+    concatSelectionNonFlat: concatSelectionNonFlat
 };
 
 function findItem(root: TreeviewItem, value: any): TreeviewItem {
@@ -84,6 +85,20 @@ function concatSelection(items: TreeviewItem[], checked: TreeviewItem[], uncheck
     let uncheckedItems = [...unchecked];
     for (const item of items) {
         const selection = item.getSelection();
+        checkedItems = concat(checkedItems, selection.checkedItems);
+        uncheckedItems = concat(uncheckedItems, selection.uncheckedItems);
+    }
+    return {
+        checked: checkedItems,
+        unchecked: uncheckedItems
+    };
+}
+
+function concatSelectionNonFlat(items: TreeviewItem[], checked: TreeviewItem[], unchecked: TreeviewItem[]): { [k: string]: TreeviewItem[] } {
+    let checkedItems = [...checked];
+    let uncheckedItems = [...unchecked];
+    for (const item of items) {
+        const selection = item.getSelectionNonFlat();
         checkedItems = concat(checkedItems, selection.checkedItems);
         uncheckedItems = concat(uncheckedItems, selection.uncheckedItems);
     }

--- a/src/lib/treeview-item.ts
+++ b/src/lib/treeview-item.ts
@@ -160,6 +160,38 @@ export class TreeviewItem {
         };
     }
 
+    getSelectionNonFlat(): TreeviewSelection {
+        let checkedItems: TreeviewItem[] = [];
+        let uncheckedItems: TreeviewItem[] = [];
+        if (isNil(this.internalChildren)) {
+            if (this.internalChecked) {
+                checkedItems.push(this);
+            } else {
+                uncheckedItems.push(this);
+            }
+        } else {
+            const selection = TreeviewHelper.concatSelectionNonFlat(this.internalChildren, checkedItems, uncheckedItems);
+
+            if (selection.unchecked.length <= 0) {
+                checkedItems.push(this);
+            } else if (selection.checked.length <= 0) {
+                uncheckedItems.push(this);
+            } else {
+                checkedItems = selection.checked;
+                uncheckedItems = selection.unchecked;
+            }
+        }
+
+        return {
+            checkedItems: checkedItems,
+            uncheckedItems: uncheckedItems
+        };
+    }
+
+    toString(): String {
+        return this.text;
+    }
+
     correctChecked() {
         this.internalChecked = this.getCorrectChecked();
     }

--- a/src/lib/treeview.component.ts
+++ b/src/lib/treeview.component.ts
@@ -123,7 +123,8 @@ export class TreeviewComponent implements OnChanges {
     }
 
     raiseSelectedChange() {
-        this.generateSelection();
+        if (this.config.flatSelection) this.generateSelection();
+        else this.generateSelectionNonFlat();
         const values = this.eventParser.getSelectedChange(this);
         this.selectedChange.emit(values);
     }
@@ -143,6 +144,21 @@ export class TreeviewComponent implements OnChanges {
         let uncheckedItems: TreeviewItem[] = [];
         if (!isNil(this.items)) {
             const selection = TreeviewHelper.concatSelection(this.items, checkedItems, uncheckedItems);
+            checkedItems = selection.checked;
+            uncheckedItems = selection.unchecked;
+        }
+
+        this.selection = {
+            checkedItems: checkedItems,
+            uncheckedItems: uncheckedItems
+        };
+    }
+
+    private generateSelectionNonFlat() {
+        let checkedItems: TreeviewItem[] = [];
+        let uncheckedItems: TreeviewItem[] = [];
+        if (!isNil(this.items)) {
+            const selection = TreeviewHelper.concatSelectionNonFlat(this.items, checkedItems, uncheckedItems);
             checkedItems = selection.checked;
             uncheckedItems = selection.unchecked;
         }


### PR DESCRIPTION
When all children of a node are checked only the parent node is returned in the selection, this is required in some use cases.

I cloned the code, made the change, tested it, applied to demo project, I kept the current behavior as default and added a boolean to config to control it (flatSelection).

![default](https://user-images.githubusercontent.com/7227957/51274437-e577af80-19d7-11e9-86e9-6dc1b49e3b33.png)
![non-flat-all](https://user-images.githubusercontent.com/7227957/51274438-e577af80-19d7-11e9-92c4-4b96c7d3f45a.png)
![non-flat-some](https://user-images.githubusercontent.com/7227957/51274439-e6104600-19d7-11e9-9490-9e1ce50f031b.png)

