### PR TITLE
add checked interpretation to treeview pipe

### DIFF
--- a/src/lib/treeview.pipe.spec.ts
+++ b/src/lib/treeview.pipe.spec.ts
@@ -22,4 +22,43 @@ describe('TreeviewPipe', () => {
         expect(objects[0].name === treeItems[0].text && objects[1].name === treeItems[1].text).toBe(true, 'validate text');
         expect(objects[0] === treeItems[0].value && objects[1] === treeItems[1].value).toBe(true, 'validate value');
     });
+
+    it('transforms a list of objects to list of TreeItem objects that include checked property', () => {
+        const objects: any[] = [{
+            name: 'leo',
+            age: '18',
+            checked: true
+        }, {
+            name: 'vo',
+            age: '14',
+            checked: false
+        }];
+
+        const treeItems = pipe.transform(objects, 'name');
+        expect(objects.length === treeItems.length).toBe(true, 'same length');
+        expect(objects[0].name === treeItems[0].text && objects[1].name === treeItems[1].text).toBe(true, 'validate text');
+        expect(objects[0] === treeItems[0].value && objects[1] === treeItems[1].value).toBe(true, 'validate value');
+        expect(objects[0].checked === treeItems[0].value.checked
+            && objects[1].checked === treeItems[1].value.checked).toBe(true, 'validate checked');
+    });
+
+    it('only includes checked property when provided', () => {
+        const objects: any[] = [{
+            name: 'leo',
+            age: '18',
+        }, {
+            name: 'vo',
+            age: '14',
+            checked: false
+        }];
+
+        const treeItems = pipe.transform(objects, 'name');
+        expect(objects.length === treeItems.length).toBe(true, 'same length');
+        expect(objects[0].name === treeItems[0].text && objects[1].name === treeItems[1].text).toBe(true, 'validate text');
+        expect(objects[0] === treeItems[0].value && objects[1] === treeItems[1].value).toBe(true, 'validate value');
+        expect(objects[0].checked === treeItems[0].value.checked
+            && objects[1].checked === treeItems[1].value.checked).toBe(true, 'validate checked');
+        expect(treeItems[1].checked).toBe(false);
+    });
+
 });

--- a/src/lib/treeview.pipe.ts
+++ b/src/lib/treeview.pipe.ts
@@ -11,6 +11,16 @@ export class TreeviewPipe implements PipeTransform {
             return undefined;
         }
 
-        return objects.map(object => new TreeviewItem({ text: object[textField], value: object }));
+        return objects.map(object => {
+            const baseObject: any = { text: object[textField], value: object };
+
+            if (baseObject.value.checked !== undefined) {
+                baseObject.checked = object.checked;
+            }
+
+            const treeviewItem = new TreeviewItem(baseObject);
+
+            return treeviewItem;
+        });
     }
 }


### PR DESCRIPTION
Fix for Issue #184 

Allows pipe to interpret incoming object's "checked" property to apply as initial value when constructing corresponding TreeviewItems.