### PR TITLE
Filtering by own parameter

### DIFF
--- a/src/lib/treeview.component.ts
+++ b/src/lib/treeview.component.ts
@@ -128,6 +128,8 @@ export class TreeviewComponent implements OnChanges {
         this.selectedChange.emit(values);
     }
 
+    itemTofilteredText = item => item.text.toLowerCase();
+
     private createHeaderTemplateContext() {
         this.headerTemplateContext = {
             config: this.config,
@@ -172,7 +174,7 @@ export class TreeviewComponent implements OnChanges {
     }
 
     private filterItem(item: TreeviewItem, filterText: string): TreeviewItem {
-        const isMatch = includes(item.text.toLowerCase(), filterText);
+        const isMatch = includes(this.itemTofilteredText(item), filterText);
         if (isMatch) {
             return item;
         } else {


### PR DESCRIPTION
Hello all,
I'm currently trying to filter in tree without diacritic but i want render tree with diacritic. I need filter by other parameter than `item.text`.

your function for filter item is:
```javascript
private filterItem(item: TreeviewItem, filterText: string): TreeviewItem {
        const isMatch = includes(item.text.toLowerCase(), filterText);
        if (isMatch) {
            return item;
        } else {
            if (!isNil(item.children)) {
                const children: TreeviewItem[] = [];
                item.children.forEach(child => {
                    const newChild = this.filterItem(child, filterText);
                    if (!isNil(newChild)) {
                        children.push(newChild);
                    }
                });
                if (children.length > 0) {
                    const newItem = new FilterTreeviewItem(item);
                    newItem.collapsed = false;
                    newItem.children = children;
                    return newItem;
                }
            }
        }

        return undefined;
    }
```
but there i don't want 
```javascript
const isMatch = includes(item.text.toLowerCase(), filterText);
```
I have this solution: (function where i set item for filtering (value without diacritic))
```javascript
const isMatch = includes(this.itemTofilteredText(item), filterText);
//where 
itemTofilteredText = item => item.textNoDiacritic.toLowerCase();
```
default for this function can be:
```javascript
 itemTofilteredText = item => item.text.toLowerCase();
```
