### PR TITLE
Get parent node value on selectChange

### DIFF
--- a/projects/ngx-treeview/src/lib/models/treeview-item.ts
+++ b/projects/ngx-treeview/src/lib/models/treeview-item.ts
@@ -149,6 +149,11 @@ export class TreeviewItem {
         uncheckedItems.push(this);
       }
     } else {
+      if (this.internalChecked) {
+        checkedItems.push(this);
+      } else {
+        uncheckedItems.push(this);
+      }
       const selection = TreeviewHelper.concatSelection(this.internalChildren, checkedItems, uncheckedItems);
       checkedItems = selection.checked;
       uncheckedItems = selection.unchecked;


### PR DESCRIPTION
When clicking on the Parent node it does not return the parent node value.